### PR TITLE
Random Helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,20 +20,23 @@ HTMLBars template helpers for doing basic arithmetic operations
 
 ## Usage
 
-Helper | JavaScript               | HTMLBars
--------|--------------------------|-------------------
-add    | `a + b`                  | `{{add a b}}`
-ceil   | `Math.ceil(a)`           | `{{ceil a}}`
-div    | `a / b`                  | `{{div a b}}`
-floor  | `Math.floor(a)`          | `{{floor a}}`
-max    | `Math.max([a, b, c...])` | `{{max a b c }}`
-min    | `Math.min([a, b, c...])` | `{{min a b c }}`
-mod    | `a % b`                  | `{{mod a b}}`
-mult   | `a * b`                  | `{{mult a b}}`
-pow    | `Math.pow(a, b)`         | `{{pow a b}}`
-round  | `Math.round(a)`          | `{{round a}}`
-sqrt   | `Math.sqrt(a)`           | `{{sqrt a}}`
-sub    | `a - b`                  | `{{sub a b}}`
+Helper                                       | JavaScript                                                                | HTMLBars
+---------------------------------------------|---------------------------------------------------------------------------|--------------
+add                                          | `a + b`                                                                   | `{{add a b}}`
+ceil                                         | `Math.ceil(a)`                                                            | `{{ceil a}}`
+div                                          | `a / b`                                                                   | `{{div a b}}`
+floor                                        | `Math.floor(a)`                                                           | `{{floor a}}`
+max                                          | `Math.max([a, b, c...])`                                                  | `{{max a b c }}`
+min                                          | `Math.min([a, b, c...])`                                                  | `{{min a b c }}`
+mod                                          | `a % b`                                                                   | `{{mod a b}}`
+mult                                         | `a * b`                                                                   | `{{mult a b}}`
+pow                                          | `Math.pow(a, b)`                                                          | `{{pow a b}}`
+random (No Args) [, decimals]                | `Math.random()`, `decimals` sets precision from 0-20 (default: 0)         | `{{random}}` or `{{random decimals=4}}`
+random (Upper Bound) [, round]               | capped `Math.random()`, `decimals` sets precision from 0-20 (default: 0)  | `{{random 42}}` or `{{random 42 decimals=4}}`
+random (Upper Bound, Lower Bound) [, round]) | bounded `Math.random()`, `decimals` sets precision from 0-20 (default: 0) | `{{random 21 1797}}` or `{{random 21 1797 decimals=4}}`
+round                                        | `Math.round(a)`                                                           | `{{round a}}`
+sqrt                                         | `Math.sqrt(a)`                                                            | `{{sqrt a}}`
+sub                                          | `a - b`                                                                   | `{{sub a b}}`
 
 You can pass as many arguments as you would like to the helpers. For something like
 `10 - 1 - 2 - 3` you could do:

--- a/addon/helpers/random.js
+++ b/addon/helpers/random.js
@@ -1,0 +1,51 @@
+import Ember from 'ember';
+
+const { Helper } = Ember;
+const { isArray } = Array;
+const { min, max } = Math;
+
+// @see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed#max(0, min(MAX_DECIMALS, decimals))));
+const MAX_DECIMALS = 20;
+
+// 💡 Using Number.toFixed, we'll get rounding for free alongside
+// decimal precision. We'll default to whole-number rounding simply
+// by defaulting `decimals` to 0
+const DEFAULT_OPTS = {
+  decimals: 0
+};
+
+export function random(params, { decimals } = DEFAULT_OPTS) {
+  // no positional or named args: just return Math.random() w/ default decimal precision
+  if (typeof params === 'undefined') {
+    return +(Math.random().toFixed(max(0, min(MAX_DECIMALS, decimals))));
+  }
+
+  // no positional args, but only an options hash from named args
+  if (typeof params === 'object' && !isArray(params)) {
+    decimals = typeof params.decimals !== 'undefined' ? params.decimals : DEFAULT_OPTS.decimals;
+
+    return +(Math.random().toFixed(max(0, min(MAX_DECIMALS, decimals))));
+  }
+
+  // one positional arg: treat it as an upper bound
+  if (params.length === 1) {
+    let [upperBound] = params;
+
+    return +((Math.random() * upperBound).toFixed(max(0, min(MAX_DECIMALS, decimals))));
+  }
+
+  // two positional args: use them to derive upper and lower bounds
+  if (params.length === 2) {
+    let [lowerBound, upperBound] = params;
+
+    // for convinience, swap if a higher number is accidentally passed first
+    if (upperBound < lowerBound) {
+      [lowerBound, upperBound] = [upperBound, lowerBound];
+    }
+    return +((lowerBound + (Math.random() * (upperBound - lowerBound))).toFixed(max(0, min(MAX_DECIMALS, decimals))));
+  }
+
+  return params;
+}
+
+export default Helper.helper(random);

--- a/addon/helpers/random.js
+++ b/addon/helpers/random.js
@@ -16,7 +16,7 @@ const DEFAULT_OPTS = {
 
 export function random(params, { decimals } = DEFAULT_OPTS) {
   // no positional or named args: just return Math.random() w/ default decimal precision
-  if (typeof params === 'undefined') {
+  if (typeof params === 'undefined' || (isArray(params) && !params.length)) {
     return +(Math.random().toFixed(max(0, min(MAX_DECIMALS, decimals))));
   }
 

--- a/app/helpers/random.js
+++ b/app/helpers/random.js
@@ -1,0 +1,1 @@
+export { default, random } from 'ember-math-helpers/helpers/random';

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -18,6 +18,7 @@ body {
   color: $whiteish;
   font-family: 'Pier Sans', sans-serif;
   font-size: 1.5rem;
+  padding: 1rem 1.3rem;
 }
 
 h1 {
@@ -25,4 +26,23 @@ h1 {
     font-family: 'Pacifico';
   }
   font-size: 6vw;
+}
+
+.result {
+  margin-left: 0.5em;
+  color: $bloodOrange;
+}
+
+.centered {
+  text-align: center;
+}
+
+.content-section {
+  padding: 1rem 1.5rem;
+}
+
+.category-list {
+  padding: 0;
+  margin: 0;
+  list-style-type: none;
 }

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -7,41 +7,57 @@
 </centered>
 
 <centered>
-  1 + 2 = {{add 1 2}}
+  1 + 2 = <span class="result">{{add 1 2}}</span>
 </centered>
 
 <centered>
-  20 / 10 = {{div 20 10}}
+  20 / 10 = <span class="result">{{div 20 10}}</span>
 </centered>
 
 <centered>
-  11 % 10 = {{mod 11 10}}
+  11 % 10 = <span class="result">{{mod 11 10}}</span>
 </centered>
 
 <centered>
-  6 * 6 = {{mult 6 6}}
+  6 * 6 = <span class="result">{{mult 6 6}}</span>
 </centered>
 
 <centered>
-  10 - 2 = {{sub 10 2}}
+  10 - 2 = <span class="result">{{sub 10 2}}</span>
 </centered>
 
 <centered>
-  10 - 1 - 2 - 3 = {{sub 10 1 2 3}}
+  10 - 1 - 2 - 3 = <span class="result">{{sub 10 1 2 3}}</span>
 </centered>
 
 <centered>
-  (15 + 5) / 2 * 10 = {{mult (div (add 15 5) 2) 10}}
+  (15 + 5) / 2 * 10 = <span class="result">{{mult (div (add 15 5) 2) 10}}</span>
 </centered>
 
 <centered>
-  Minimum of array: [2, 3, 5, 3, 26, 7, 123] = {{min 2 3 5 3 26 7 123}}
+  Minimum of array: [2, 3, 5, 3, 26, 7, 123] = <span class="result">{{min 2 3 5 3 26 7 123}}</span>
 </centered>
 
 <centered>
-  Maximum of array: [5, 2, 134, 125, 1234, 5234, 2] = {{max 5 2 134 125 1234 5234 2}}
+  Maximum of array: [5, 2, 134, 125, 1234, 5234, 2] = <span class="result">{{max 5 2 134 125 1234 5234 2}}</span>
 </centered>
 
 <centered>
-  21.23 rounded to the nearest whole number = {{round 21.23}}
+  21.23 rounded to the nearest whole number = <span class="result">{{round 21.23}}</span>
+</centered>
+
+{{!-- <section class="centered content-section"> --}}
+<centered>
+  <h3>Random Numbers</h3>
+</centered>
+
+<centered>
+  <ul class="category-list">
+    <centered><li>Integer (0 - 1): <span class="result">{{random}}</span></li></centered>
+    <centered><li>Bounded Int (0 - 42): <span class="result">{{random 42}}</span></li></centered>
+    <centered><li>Bounded Int (21 - 1797): <span class="result">{{random 21 1797}}</span></li></centered>
+    <centered><li>Float, 2 decimals (0 - 1): <span class="result">{{random decimals=2}}</span></li></centered>
+    <centered><li>Float, 4 decimals (0 - 1): <span class="result">{{random decimals=4}}</span></li></centered>
+    <centered><li>Bounded Float, 1 decimal (20 - 93): <span class="result">{{random 93 20 decimals=1}}</span></li></centered>
+  </ul>
 </centered>

--- a/tests/helpers/range.js
+++ b/tests/helpers/range.js
@@ -1,0 +1,1 @@
+export default (start, end) => Array.from({ length: end - start + 1 }, (x, idx) => start + idx);

--- a/tests/unit/helpers/random-test.js
+++ b/tests/unit/helpers/random-test.js
@@ -1,0 +1,128 @@
+import { random } from 'dummy/helpers/random';
+import range from '../../helpers/range';
+import { module, test } from 'qunit';
+
+const { floor } = Math;
+const SAMPLE_SIZE = 100;
+const PRECISION = 6;
+
+// 💡 Because precise decimals aren't zero-padded, we can
+// tolerate some percentage of failures when dealing with decimal length
+const TOLERANCE = 0.25;  // 75% pass-rate
+
+let randVal, satisfied, passCount, message;
+
+module('Unit | Helper | random');
+
+function isPassing(passCount, sampleSize, toleranceRatio) {
+  return passCount >= floor(sampleSize * (1 - toleranceRatio));
+}
+
+function hasDecimal(value) {
+  return value.toString().search(/\./) !== -1;
+}
+
+function numDecimals(floatingPointNum) {
+  return floatingPointNum.toPrecision().split('.')[1].length;
+}
+
+test('no positional arguments', function(assert) {
+  message = 'defaults to returning the whole numbers of either 0 or 1';
+
+  passCount = range(1, SAMPLE_SIZE).reduce((acc) => {
+    randVal = random();
+    satisfied = randVal === 0 || randVal === 1;
+
+    return satisfied ? acc + 1 : acc;
+  }, 0);
+
+  assert.ok(isPassing(passCount, SAMPLE_SIZE, TOLERANCE), message);
+
+  message = 'returns a number between 0 and 1, with decimal precision specified by `decimals`';
+
+  passCount = range(1, SAMPLE_SIZE).reduce((acc) => {
+    randVal = random({ decimals: PRECISION });
+
+    satisfied = ((randVal > 0 && randVal < 1) && numDecimals(randVal) === PRECISION);
+
+    return satisfied ? acc + 1 : acc;
+  }, 0);
+
+  assert.ok(isPassing(passCount, SAMPLE_SIZE, TOLERANCE), message);
+});
+
+test('one positional argument', function(assert) {
+  message = 'returns a random whole number between 0 and 42, inclusive';
+
+  passCount = range(1, SAMPLE_SIZE).reduce((acc) => {
+    randVal = random([42]);
+
+    satisfied = ((randVal >= 0 && randVal <= 42) && !hasDecimal(randVal));
+
+    return satisfied ? acc + 1 : acc;
+  }, 0);
+
+  assert.ok(isPassing(passCount, SAMPLE_SIZE, TOLERANCE), message);
+
+  message = 'returns a random number between 0 and a single positional arg, with decimal precision specified by `decimals`';
+  passCount = range(1, SAMPLE_SIZE).reduce((acc) => {
+    randVal = random([42], { decimals: PRECISION });
+
+    satisfied = ((randVal > 0 && randVal < 42) && numDecimals(randVal) === PRECISION);
+
+    return satisfied ? acc + 1 : acc;
+  }, 0);
+
+  assert.ok(isPassing(passCount, SAMPLE_SIZE, TOLERANCE), message);
+});
+
+test('two positional arguments', function(assert) {
+  message = 'returns a random whole number between two upper and lower bound postional args, inclusive';
+  passCount = range(1, SAMPLE_SIZE).reduce((acc) => {
+    randVal = random([21, 1797]);
+
+    satisfied = ((randVal >= 21 && randVal <= 1797) && !hasDecimal(randVal));
+
+    return satisfied ? acc + 1 : acc;
+  }, 0);
+
+  assert.ok(isPassing(passCount, SAMPLE_SIZE, TOLERANCE), message);
+
+  message = 'returns a random number between two upper and lower bound postional args, with decimal precision specified by `decimals`';
+  passCount = range(1, SAMPLE_SIZE).reduce((acc) => {
+    randVal = random([21, 1797], { decimals: PRECISION });
+
+    satisfied = ((randVal >= 21 && randVal <= 1797) && numDecimals(randVal) === PRECISION);
+
+    return satisfied ? acc + 1 : acc;
+  }, 0);
+
+  assert.ok(isPassing(passCount, SAMPLE_SIZE, TOLERANCE), message);
+});
+
+test('bounding `decimals` between 0 and 20', function(assert) {
+  randVal = random([42], { decimals: -100 });
+  satisfied = (randVal > 0 && randVal < 42) && !hasDecimal(randVal);
+
+  assert.ok(satisfied);
+
+  randVal = random([42], { decimals: null });
+  satisfied = (randVal > 0 && randVal < 42) && !hasDecimal(randVal);
+
+  assert.ok(satisfied);
+
+  randVal = random([42], { decimals: undefined });
+  satisfied = (randVal > 0 && randVal < 42) && !hasDecimal(randVal);
+
+  assert.ok(satisfied);
+
+  randVal = random([42], { decimals: 0 });
+  satisfied = (randVal > 0 && randVal < 42) && !hasDecimal(randVal);
+
+  assert.ok(satisfied);
+
+  randVal = random([42], { decimals: 100 });
+  satisfied = (randVal > 0 && randVal < 42) && numDecimals(randVal) <= 20;
+
+  assert.ok(satisfied);
+});


### PR DESCRIPTION
This PR implements a random helper and provides an interface for upper-bounded randoms, lower- _and_ upper-bounded randoms, and the option to configure decimal precision.

I filled out the [README table](https://github.com/shipshapecode/ember-math-helpers/pull/25/files#diff-04c6e90faac2675aa89e2176d2eec7d8R34) with a bit more explanation (which, I'll admit, does widen the Markdown a bit. I'd be up for writing a set of full-text descriptions as we go on).

I also added some `random` examples to the dummy app demo and gave its results a slight color flourish. One thing to note, though, I'm not quite familiar with using `flexi`, so I broke from that a bit in the template. @rwwagner90, if you had a suggestion for "flexi way" of [marking this up](https://github.com/shipshapecode/ember-math-helpers/compare/master...BrianSipple:random?expand=1#diff-33efff51085b97215b246f6fcfd9e0feR49), I can definitely update and rebase.