### PR TITLE
Remove log helper from app namespace.

### DIFF
--- a/app/helpers/log.js
+++ b/app/helpers/log.js
@@ -1,1 +1,0 @@
-export { default, log } from 'ember-math-helpers/helpers/log';


### PR DESCRIPTION
This removes the old helper export file from the app namespace, which was stomping and causing an error with the Ember log helper. 