### PR TITLE
Read options from parent or app

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,9 +18,9 @@ module.exports = {
     }
 
     this.app = app;
-    this.app.options = this.app.options || {};
 
-    var config = this.app.options[this.name] || {};
+    var addonOptions = (this.parent && this.parent.options) || (this.app && this.app.options) || {};
+    var config = addonOptions[this.name] || {};
     this.whitelist = this.generateWhitelist(config);
     this.blacklist = this.generateBlacklist(config);
   },


### PR DESCRIPTION
The PR makes ember-math-helpers read its options from either this.parent or this.app.

The "issue" is that relying only on this.app makes it impossible to configure from within an engine.
The changed code is copied from [ember-cli-babel](https://github.com/babel/ember-cli-babel/blob/master/index.js#L137) and [ember-composable-helpers](https://github.com/DockYard/ember-composable-helpers/blob/master/index.js#L22-L23).