### PR TITLE
update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,19 @@
-# 2.4.0
+# 2.7.0 (2018-09-04)
+* Implement `gcd` helper [#136](https://github.com/shipshapecode/ember-math-helpers/pull/136)
+
+# 2.6.0 (2018-07-30)
+* Bump to Ember 3.3.0
+* Bump to Ember CLI 3.3.0
+
+# 2.5.0 (2018-05-11)
+* Bump to Ember 3.2.0 beta
+* Bump to Ember CLI 3.1.1
+
+# 2.4.1 (2018-04-09)
+* Bump to Ember 3.1 beta and upgrade dependencies
+* Remove unused test helpers 
+
+# 2.4.0 (2018-01-02)
 * Bump to Ember 3.0 beta
 
 # 2.2.4


### PR DESCRIPTION
@rwwagner90 I think we could do a `2.7.0` release after #136. I wanted to get the `CHANGELOG` up to date ahead of that, though.