### PR TITLE
remove .bowerrc

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,4 +1,0 @@
-{
-  "directory": "bower_components",
-  "analytics": false
-}


### PR DESCRIPTION
This should no longer be needed now that we aren't getting anything from `bower`.