### PR TITLE
Filter app/ files

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,13 @@ module.exports = {
     return this.filterHelpers(tree, new RegExp(moduleRegexp, 'i'));
   },
 
+  treeForApp() {
+    // see: https://github.com/ember-cli/ember-cli/issues/4463
+    var tree = this._super.treeForApp.apply(this, arguments);
+    var moduleRegexp = '^helpers\/';
+    return this.filterHelpers(tree, new RegExp(moduleRegexp, 'i'));
+  },
+
   filterHelpers(tree, regex) {
     var whitelist = this.whitelist;
     var blacklist = this.blacklist;


### PR DESCRIPTION
This addon allows to filter the helper code defined in `addon/`,  but even if you filter some helpers the module exports stills being included in the app tree. This pull aims to fix that, reducing a little the bundle size when filtering helpers.

To test that it works you can build the dummy app adding some `only` or `except` rules, and checking that the `vendor.js/dummy.js` includes the same helpers.