### PR TITLE
exclude deploy-docs from publish

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -24,6 +24,7 @@
 /config/ember-try.js
 /CONTRIBUTING.md
 /docs/
+/deploy-docs/
 /ember-cli-build.js
 /testem.js
 /tests/
@@ -38,3 +39,4 @@
 
 .idea/
 /config/addon-docs.js
+


### PR DESCRIPTION
This is increasing the package size from 0.39 MB to 44.39 MB